### PR TITLE
Fixing @Ok annotation to comply with Spring 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pro.nikolaev</groupId>
     <artifactId>rest-utils</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/pro/nikolaev/restutils/annotations/swagger/success/Ok.java
+++ b/src/main/java/pro/nikolaev/restutils/annotations/swagger/success/Ok.java
@@ -18,6 +18,7 @@ package pro.nikolaev.restutils.annotations.swagger.success;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,5 +47,6 @@ import java.lang.annotation.*;
 @ApiResponse(responseCode = "200", description = "Успешно", useReturnTypeSchema = true)
 @Documented
 public @interface Ok {
+    @AliasFor(annotation = ApiResponse.class, attribute = "content")
     Content[] content() default {};
 }


### PR DESCRIPTION
Fixing @Ok annotation to comply with Spring 6.2 deprecation of convention-based annotation attribute overrides in favor of @AliasFor